### PR TITLE
Public partial class Welcome removed from class User

### DIFF
--- a/DotNetStandardApi/Entities/User.cs
+++ b/DotNetStandardApi/Entities/User.cs
@@ -7,28 +7,25 @@ namespace KoenZomers.Tado.Api.Entities
     /// </summary>
     public class User
     {
-        public partial class Welcome
-        {
-            [JsonProperty("name")]
-            public string Name { get; set; }
+        [JsonProperty("name")]
+        public string Name { get; set; }
 
-            [JsonProperty("email")]
-            public string Email { get; set; }
+        [JsonProperty("email")]
+        public string Email { get; set; }
 
-            [JsonProperty("username")]
-            public string Username { get; set; }
+        [JsonProperty("username")]
+        public string Username { get; set; }
 
-            [JsonProperty("id")]
-            public string Id { get; set; }
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-            [JsonProperty("homes")]
-            public Home[] Homes { get; set; }
+        [JsonProperty("homes")]
+        public Home[] Homes { get; set; }
 
-            [JsonProperty("locale")]
-            public string Locale { get; set; }
+        [JsonProperty("locale")]
+        public string Locale { get; set; }
 
-            [JsonProperty("mobileDevices")]
-            public MobileDevice.Item[] MobileDevices { get; set; }
-        }
+        [JsonProperty("mobileDevices")]
+        public MobileDevice.Item[] MobileDevices { get; set; }
     }
 }


### PR DESCRIPTION
The partial class should not be there. Now It breaks functions like session.GetMe(), because the JsonConvert.DeserializeObject cannot convert it correctly.


