### PR TITLE
Add "set home presence" feature

### DIFF
--- a/DotNetStandardApi/.NET Standard API.csproj
+++ b/DotNetStandardApi/.NET Standard API.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>KoenZomers.Tado.Api</AssemblyName>
+    <RootNamespace>KoenZomers.Tado.Api</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>0.4.0.1</Version>
     <Authors>Koen Zomers</Authors>

--- a/DotNetStandardApi/Enums/HomePresence.cs
+++ b/DotNetStandardApi/Enums/HomePresence.cs
@@ -1,0 +1,8 @@
+﻿namespace KoenZomers.Tado.Api.Enums
+{
+    public enum HomePresence
+    {
+        HOME,
+        AWAY,
+    }
+}

--- a/DotNetStandardApi/Helpers/EnumValidation.cs
+++ b/DotNetStandardApi/Helpers/EnumValidation.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace KoenZomers.Tado.Api.Helpers
+{
+    internal static class EnumValidation
+    {
+        internal static void EnsureEnumWithinRange<TEnum>(TEnum value) where TEnum : struct, IConvertible
+        {
+            if (!typeof(TEnum).IsEnum)
+            {
+                throw new ArgumentException($"{nameof(TEnum)} must be an enumeration type.");
+            }
+
+            if (!Enum.IsDefined(typeof(TEnum), value))
+            {
+                throw new ArgumentOutOfRangeException($"Value: '{value}' is not within enumeration range of type: '{typeof(TEnum).Name}'");
+            }
+        }
+    }
+}

--- a/DotNetStandardApi/Session.cs
+++ b/DotNetStandardApi/Session.cs
@@ -1,10 +1,12 @@
-﻿using System;
-using System.Text;
-using System.Threading.Tasks;
+﻿using KoenZomers.Tado.Api.Enums;
+using KoenZomers.Tado.Api.Helpers;
 using Newtonsoft.Json;
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace KoenZomers.Tado.Api
 {
@@ -842,6 +844,23 @@ namespace KoenZomers.Tado.Api
         public async Task<Entities.ZoneSummary> SwitchHeatingOff(int homeId, int zoneId, Enums.DurationModes durationMode, TimeSpan? timer = null)
         {
             return await SetTemperature(homeId, zoneId, null, null, Enums.DeviceTypes.Heating, durationMode, timer);
+        }
+
+        /// <summary>
+        /// Sets the Home Presence mode manually, regardless of current geofence status of home devices.
+        /// </summary>
+        /// <param name="homeId">Id of the home to set the home presence for.</param>
+        /// <param name="presence">Presence to set for the home.</param>
+        /// <returns>Boolean indicating if the request was successful</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when an invalid enum value is used.</exception>
+        public Task<bool> SetHomePresence(int homeId, HomePresence presence)
+        {
+            EnsureAuthenticatedSession();
+            EnumValidation.EnsureEnumWithinRange(presence);
+
+            var request = JsonConvert.SerializeObject(new { homePresence = presence.ToString() });
+
+            return SendMessage(request, HttpMethod.Put, new Uri(TadoApiBaseUrl, $"homes/{homeId}/presenceLock"), HttpStatusCode.NoContent);
         }
 
         /// <summary>

--- a/UnitTest/DataSetTest.cs
+++ b/UnitTest/DataSetTest.cs
@@ -211,5 +211,13 @@ namespace KoenZomers.Tado.Api.UnitTest
                 await session.SwitchHotWaterOff(HomeId, zone.Termination.CurrentType.Value);
             }
         }
+
+        [TestMethod]
+        public async Task SwitchHomePresenceAwayThenHomeTest()
+        {
+            Assert.IsTrue(await session.SetHomePresence(HomeId, Enums.HomePresence.AWAY));
+
+            Assert.IsTrue(await session.SetHomePresence(HomeId, Enums.HomePresence.HOME));
+        }
     }
 }


### PR DESCRIPTION
Uses the new `PUT` endpoint in the Tado API at: `https://my.tado.com/api/v2/homes/{homeId}/presenceLock`.

It needs a body that specifies which of the two presences you want to set:
```json
{
    "homePresence": "{AWAY|HOME}"
}
```